### PR TITLE
fix(clippy): Ran `cargo clippy --fix`

### DIFF
--- a/src/string.rs
+++ b/src/string.rs
@@ -133,7 +133,7 @@ impl EcoString {
                 // We have the invariant len <= LIMIT.
                 unsafe { buf.get_unchecked(..usize::from(*len)) }
             }
-            Repr::Large(vec) => &vec,
+            Repr::Large(vec) => vec,
         };
 
         // Safety:

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -154,7 +154,7 @@ fn test_vec_more_mutations() {
     vec.push("where?");
     vec.insert(1, "wonder!");
     assert_eq!(vec, ["hello,", "wonder!", "what's", "going", "where?"]);
-    vec.retain(|s| s.starts_with("w"));
+    vec.retain(|s| s.starts_with('w'));
     assert_eq!(vec, ["wonder!", "what's", "where?"]);
     vec.truncate(1);
     assert_eq!(vec.last(), vec.first());

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -666,7 +666,7 @@ impl<T> EcoVec<T> {
             .and_then(|size| Self::offset().checked_add(size))
             .filter(|&size| {
                 // See `Layout::max_size_for_align` for details.
-                size <= isize::MAX as usize - Self::align() - 1
+                size < isize::MAX as usize - Self::align()
             })
             .unwrap_or_else(|| capacity_overflow())
     }
@@ -946,14 +946,14 @@ impl<T: PartialEq> PartialEq<EcoVec<T>> for Vec<T> {
 impl<T: Ord> Ord for EcoVec<T> {
     #[inline]
     fn cmp(&self, other: &Self) -> Ordering {
-        self.as_slice().cmp(&other.as_slice())
+        self.as_slice().cmp(other.as_slice())
     }
 }
 
 impl<T: PartialOrd> PartialOrd for EcoVec<T> {
     #[inline]
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        self.as_slice().partial_cmp(&other.as_slice())
+        self.as_slice().partial_cmp(other.as_slice())
     }
 }
 


### PR DESCRIPTION
It removed some unnecessary references and changed a `str` comparison to a `char` comparison, it also removed a `clone` in a test case, but I kept it because it seemed intentional.