### PR TITLE
Setup GitHub actions for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,36 +23,17 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
             toolchain: ${{ matrix.rust }}
-            components: clippy, rustfmt
+            components: rustfmt
       - name: Check formatting
         run: cargo fmt --all --check
-      - name: Check clippy
-        run: cargo clippy -- -D warnings
+      - name: Check check
+        run: cargo check -- -D warnings
       - name: Run test suite
         run: cargo test
       - name: Check docs
         env:
           RUSTDOCFLAGS: -D warnings
         run: cargo doc --no-deps --document-private-items
-
-  # Keeping clippy lints happy across a lot of versions is a nightmare, so only
-  # check and test on MSRV without worrying about warnings
-  msrv_only:
-    name: MSRV tasks
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
-      - name: Install MSRV toolchain
-        uses: dtolnay/rust-toolchain@master
-        with:
-            # IMPORTANT: Update the `rust-version` in the `Cargo.toml` when you
-            # change this
-            toolchain: 1.58.1
-      - name: Check
-        run: cargo check
-      - name: Test
-        run: cargo test
 
   # We use a healthy amount of unsafe, so run tests with Miri to check for UB
   nightly_only:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Install MSRV toolchain
+      - name: Install nightly toolchain
         uses: dtolnay/rust-toolchain@master
         with:
             toolchain: nightly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   push:
   pull_request:
+  schedule:
     # Run weekly to keep Rust toolchain changes fresh
     - cron: '0 0 * * 1'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,69 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+    # Run weekly to keep Rust toolchain changes fresh
+    - cron: '0 0 * * 1'
+
+jobs:
+  multiple_toolchains:
+    name: Stable and Beta tasks
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - stable
+          - beta
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install ${{ matrix.rust }} toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+            toolchain: ${{ matrix.rust }}
+            components: clippy, rustfmt
+      - name: Check formatting
+        run: cargo fmt --all --check
+      - name: Check clippy
+        run: cargo clippy -- -D warnings
+      - name: Run test suite
+        run: cargo test
+      - name: Check docs
+        env:
+          RUSTDOCFLAGS: -D warnings
+        run: cargo doc --no-deps --document-private-items
+
+  # Keeping clippy lints happy across a lot of versions is a nightmare, so only
+  # check and test on MSRV without worrying about warnings
+  msrv_only:
+    name: MSRV tasks
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install MSRV toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+            # IMPORTANT: Update the `rust-version` in the `Cargo.toml` when you
+            # change this
+            toolchain: 1.58.1
+      - name: Check
+        run: cargo check
+      - name: Test
+        run: cargo test
+
+  # We use a healthy amount of unsafe, so run tests with Miri to check for UB
+  nightly_only:
+    name: Nightly tasks
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install MSRV toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+            toolchain: nightly
+            components: miri
+      - name: Miri
+        run: cargo miri test


### PR DESCRIPTION
This sets up and action that runs on:
- Pushes
- Pull requests
- A weekly schedule (to proactively point out any new warnings from new stable/beta releases)

This enforces:
- `cargo fmt`, `cargo clippy`, `cargo test`, and `cargo doc` warnings and hard errors on stable and beta
- `cargo check` and `cargo test` hard errors on an MSRV version
- `cargo miri test` on nightly