### PR TITLE
Run doctests on the `README.md`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,3 +52,8 @@ pub use vec::*;
 
 #[cfg(test)]
 mod tests;
+
+// Run doctests on the README too
+#[doc = include_str!("../README.md")]
+#[cfg(doctest)]
+pub struct ReadmeDoctests;


### PR DESCRIPTION
Runs doctests on the `README.md` to prevent the code examples from getting stale