### PR TITLE
Pass deny warnings to rust for `cargo check`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,9 @@ jobs:
       - name: Check formatting
         run: cargo fmt --all --check
       - name: Check check
-        run: cargo check -- -D warnings
+        env:
+          RUSTFLAGS: -D warnings
+        run: cargo check
       - name: Run test suite
         run: cargo test
       - name: Check docs


### PR DESCRIPTION
_Now_ CI should be green

This fixes how warnings are denied for `cargo check`