### PR TITLE
Defensively test against mistakes found in the advisory db

### DIFF
--- a/tests/ub_guards.rs
+++ b/tests/ub_guards.rs
@@ -1,3 +1,5 @@
+use ecow::{eco_vec, EcoVec};
+
 // Guarding against something like:
 // https://github.com/servo/rust-smallvec/issues/96 aka RUSTSEC-2018-0003
 // If length isn't updated defensively then a panic when iterating could double-free a value

--- a/tests/ub_guards.rs
+++ b/tests/ub_guards.rs
@@ -1,0 +1,75 @@
+// Guarding against something like:
+// https://github.com/servo/rust-smallvec/issues/96 aka RUSTSEC-2018-0003
+// If length isn't updated defensively then a panic when iterating could double-free a value
+#[test]
+#[should_panic(expected = "Panic on next")]
+fn panicky_iterator_unwinds_correctly() {
+    struct PanicIter;
+
+    impl Iterator for PanicIter {
+        type Item = u32;
+
+        fn size_hint(&self) -> (usize, Option<usize>) {
+            (1, None)
+        }
+
+        fn next(&mut self) -> Option<Self::Item> {
+            panic!("Panic on next");
+        }
+    }
+
+    let mut v = eco_vec![1, 2, 3];
+    v.extend(PanicIter);
+}
+
+// Guarding against something like:
+// https://github.com/servo/rust-smallvec/issues/252 aka RUSTSEC-2021-0003
+// size_hint should only be treated as a hint, nothing more
+#[test]
+fn small_size_hint_is_fine() {
+    let mut v = EcoVec::new();
+    v.push(123);
+
+    let iter = (0u8..=255).filter(|n| n % 2 == 0);
+    assert_eq!(iter.size_hint().0, 0);
+
+    v.extend(iter);
+
+    assert_eq!(
+        v,
+        core::iter::once(123)
+            .chain((0u8..=255).filter(|n| n % 2 == 0))
+            .collect::<Vec<_>>()
+    );
+}
+
+// Guarding against something like:
+// https://github.com/Alexhuszagh/rust-stackvector/issues/2 aka RUSTSEC-2021-0048
+// size_hint should only be treated as a hint, nothing more
+#[test]
+fn wacky_size_hint_is_fine() {
+    struct IncorrectIterator(core::iter::Take<core::iter::Repeat<u8>>);
+
+    impl IncorrectIterator {
+        pub fn new() -> Self {
+            IncorrectIterator(core::iter::repeat(1).take(20))
+        }
+    }
+
+    impl Iterator for IncorrectIterator {
+        type Item = u8;
+
+        fn next(&mut self) -> Option<Self::Item> {
+            self.0.next()
+        }
+
+        fn size_hint(&self) -> (usize, Option<usize>) {
+            (20, Some(0))
+        }
+    }
+
+    let mut v = EcoVec::new();
+    v.extend(IncorrectIterator::new());
+
+    assert_eq!(v, IncorrectIterator::new().collect::<Vec<_>>())
+}


### PR DESCRIPTION
I figured it would be worthwhile to start digging through issues reported in [the advisory-db](https://github.com/rustsec/advisory-db). So far it hasn't found anything interesting, but this includes areas that could have issues from future optimizations (primarily avoiding extra bounds/capacity checking)

This is just the first set since there's more I would like to add (namely around panicking in either `clone()` or `drop()`, but that seems fine so far). Common sources of issues seem to be

- Wrong `Send` or `Sync` bounds: already fixed
- Forgetting to bounds check, or off by one error when bounds checking: already seems decently tested, but could be worth some property testing
- Panicking in unexpected places: everything seems to update the bounds correctly to avoid dropping things multiple times, but could use some more testing since it's something that could get some error-prone performance improvements in the future
- Using incorrect alignment: seems fine to me at a glance, and has some existing tests
- Multiple mutable references to the same data: seems to correctly check uniqueness before allowing for mutation, although some more `debug_assert!`s wouldn't hurt
- Use after free: Only issue I found was that extremely degenerate `clone()` issue. All the lifetimes seem right, so far
- Making assumptions about `#[repr(Rust)]` layout: `EcoVec` seems appropriately `#[repr(C)]` and running with `RUSTFLAGS="-Zrandomize-layout"` didn't find any issues

Still have more auditing to do, but so far things seem very solid :+1: