### PR TITLE
Restructure public api

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,9 +54,6 @@ pub mod vec;
 pub use self::string::EcoString;
 pub use self::vec::EcoVec;
 
-#[cfg(test)]
-mod tests;
-
 // Run doctests on the README too
 #[doc = include_str!("../README.md")]
 #[cfg(doctest)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,11 +48,11 @@ assert_eq!(third, "Welcome to earth! ");
 extern crate alloc;
 
 mod dynamic;
-mod string;
-mod vec;
+pub mod string;
+pub mod vec;
 
-pub use self::string::*;
-pub use self::vec::*;
+pub use self::string::EcoString;
+pub use self::vec::EcoVec;
 
 #[cfg(test)]
 mod tests;

--- a/src/string.rs
+++ b/src/string.rs
@@ -1,3 +1,6 @@
+//! [`EcoString`]: a clone-on-write small-string-optimized reference
+//! counted [`String`][alloc::string::String]
+
 use alloc::borrow::Cow;
 use alloc::string::String;
 use core::borrow::Borrow;
@@ -14,7 +17,7 @@ use crate::dynamic::{DynamicVec, InlineVec};
 /// assert_eq!(format_eco!("Hello, {}!", 123), "Hello, 123!");
 /// ```
 #[macro_export]
-macro_rules! format_eco {
+macro_rules! eco_format {
     ($($tts:tt)*) => {{
         use ::std::fmt::Write;
         let mut s = $crate::EcoString::new();
@@ -59,6 +62,15 @@ macro_rules! format_eco {
 pub struct EcoString(DynamicVec);
 
 impl EcoString {
+    /// Maximum number of bytes for an inline `EcoString` before spilling on
+    /// the heap
+    ///
+    /// The exact value for this is architecture dependent
+    ///
+    /// # Note
+    /// This value is semver exempt and can be changed with any update
+    pub const INLINE_LIMIT: usize = crate::dynamic::LIMIT;
+
     /// Create a new, empty string.
     #[inline]
     pub const fn new() -> Self {

--- a/src/string.rs
+++ b/src/string.rs
@@ -1,5 +1,5 @@
-//! [`EcoString`]: a clone-on-write small-string-optimized reference
-//! counted [`String`][alloc::string::String]
+//! A clone-on-write, small-string-optimized alternative to
+//! [`String`][alloc::string::String]
 
 use alloc::borrow::Cow;
 use alloc::string::String;
@@ -63,12 +63,12 @@ pub struct EcoString(DynamicVec);
 
 impl EcoString {
     /// Maximum number of bytes for an inline `EcoString` before spilling on
-    /// the heap
+    /// the heap.
     ///
-    /// The exact value for this is architecture dependent
+    /// The exact value for this is architecture dependent.
     ///
     /// # Note
-    /// This value is semver exempt and can be changed with any update
+    /// This value is semver exempt and can be changed with any update.
     pub const INLINE_LIMIT: usize = crate::dynamic::LIMIT;
 
     /// Create a new, empty string.

--- a/src/string.rs
+++ b/src/string.rs
@@ -13,8 +13,8 @@ use crate::dynamic::{DynamicVec, InlineVec};
 
 /// Create a new [`EcoString`] from a format string.
 /// ```
-/// # use ecow::format_eco;
-/// assert_eq!(format_eco!("Hello, {}!", 123), "Hello, 123!");
+/// # use ecow::eco_format;
+/// assert_eq!(eco_format!("Hello, {}!", 123), "Hello, 123!");
 /// ```
 #[macro_export]
 macro_rules! eco_format {

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -1,3 +1,6 @@
+//! Contains [`EcoVec`], a copy-on-write reference counted
+//! [`Vec`][alloc::vec::Vec], and related structs
+
 use alloc::vec::Vec;
 use core::alloc::Layout;
 use core::borrow::Borrow;

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -1,5 +1,4 @@
-//! Contains [`EcoVec`], a copy-on-write reference counted
-//! [`Vec`][alloc::vec::Vec], and related structs
+//! A clone-on-write alternative to [`Vec`][alloc::vec::Vec]
 
 use alloc::vec::Vec;
 use core::alloc::Layout;

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,15 +1,17 @@
 // Test with `cargo +nightly miri test` to check sanity!
 
+extern crate alloc;
+
 use alloc::boxed::Box;
 use alloc::string::ToString;
 use alloc::vec::Vec;
 use core::mem;
 use core::sync::atomic::{AtomicUsize, Ordering::*};
 
-use super::*;
-use crate::dynamic::LIMIT;
+use ecow::{eco_vec, EcoString, EcoVec};
 
 const ALPH: &str = "abcdefghijklmnopqrstuvwxyz";
+const LIMIT: usize = EcoString::INLINE_LIMIT;
 
 fn v<T>(value: T) -> Box<T> {
     Box::new(value)
@@ -169,7 +171,7 @@ fn test_vec_truncate() {
 fn test_vec_extend() {
     let mut vec = EcoVec::new();
     vec.extend_from_slice(&[]);
-    vec.extend_from_byte_slice(&[2, 3, 4]);
+    vec.extend_from_slice(&[2, 3, 4]);
     assert_eq!(vec, [2, 3, 4]);
 }
 


### PR DESCRIPTION
Resolves #18

This follows the described restructuring, renaming, and switches the unit tests to integration tests. The only change that the latter involved was switching a single call from `.extend_from_byte_slice()` to `.extend_from_slice()` since `.extend_from_byte_slice()` isn't included in the public API (and should get tested well by the `EcoString` tests anyways)