### PR TITLE
Added EcoBytes struct

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,6 @@ license = "MIT OR Apache-2.0"
 categories = ["data-structures", "no-std"]
 keywords = ["string", "vector", "sso", "cow"]
 
-[features]
-default = ["serde"]
-
 [dependencies]
 serde = { version = "1.0", optional = true, default-features = false }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ license = "MIT OR Apache-2.0"
 categories = ["data-structures", "no-std"]
 keywords = ["string", "vector", "sso", "cow"]
 
+[features]
+default = ["serde"]
+
 [dependencies]
 serde = { version = "1.0", optional = true, default-features = false }
 

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -1,11 +1,25 @@
+//! A clone-on-write, small-vector-optimized alternative to
+//! [`Vec<u8>`][alloc::vec::Vec].
+
 use core::mem::{self, ManuallyDrop};
+use core::ops::Deref;
 use core::ptr;
 
 use super::EcoVec;
 
-/// A byte vector that can hold up to 15 bytes inline and then spills to an
-/// `EcoVec<u8>`.
-pub(crate) struct DynamicVec(Repr);
+/// An economical byte vector with inline storage and clone-on-write semantics.
+///
+/// This type has a size of 16 bytes. It has 15 bytes of inline storage and
+/// starting from 16 bytes it becomes an [`EcoVec<u8>`](super::EcoVec). The
+/// internal reference counter of the heap variant is atomic, making this type
+/// [`Sync`] and [`Send`].
+///
+///
+/// # Note
+/// The above holds true for normal 32-bit or 64-bit little endian systems. On
+/// 64-bit big-endian systems, the type's size increases to 24 bytes and the
+/// amount of inline storage to 23 bytes.
+pub struct EcoBytes(Repr);
 
 /// The internal representation.
 ///
@@ -62,47 +76,77 @@ const LEN_TAG: u8 = 0b1000_0000;
 /// This is used to mask off the tag to get the inline variant's length.
 const LEN_MASK: u8 = 0b0111_1111;
 
-impl DynamicVec {
+impl EcoBytes {
+    /// Maximum number of bytes for an inline `EcoBytes` before spilling on
+    /// the heap.
+    ///
+    /// The exact value for this is architecture dependent.
+    ///
+    /// # Note
+    /// This value is semver exempt and can be changed with any update.
+    pub const INLINE_LIMIT: usize = LIMIT;
+
+    /// Create a new, empty vector.
     #[inline]
     pub const fn new() -> Self {
         Self::from_inline(InlineVec::new())
     }
 
+    /// Create a new, inline vector.
+    ///
+    /// Panics if the vector's length exceeds the capacity of the inline
+    /// storage.
     #[inline]
-    pub const fn from_inline(inline: InlineVec) -> Self {
+    pub const fn inline(bytes: &[u8]) -> Self {
+        let Ok(inline) = InlineVec::from_slice(bytes) else {
+            exceeded_inline_capacity();
+        };
+        EcoBytes::from_inline(inline)
+    }
+
+    /// Create a new, inline vector.
+    ///
+    /// Returns `Err(())` if the vector's length exceeds the capacity of
+    /// the inline storage.
+    #[inline]
+    pub const fn try_inline(bytes: &[u8]) -> Result<Self, ()> {
+        match InlineVec::from_slice(bytes) {
+            Ok(inline) => Ok(EcoBytes::from_inline(inline)),
+            _ => Err(()),
+        }
+    }
+
+    #[inline]
+    pub(crate) const fn from_inline(inline: InlineVec) -> Self {
         Self(Repr { inline })
     }
 
-    #[inline]
-    pub const fn from_eco(vec: EcoVec<u8>) -> Self {
-        // Safety:
-        // Explicitly set `tagged_len` to 0 to mark this as a spilled variant.
-        // Just initializing with `Repr { spilled: ... }` would leave
-        // `tagged_len` unitialized, leading to undefined behaviour on access.
-        let mut repr = Repr {
-            inline: InlineVec { buf: [0; LIMIT], tagged_len: 0 },
-        };
-        repr.spilled = ManuallyDrop::new(vec);
-        Self(repr)
-    }
-
+    /// Create an instance from a slice.
     #[inline]
     pub fn from_slice(bytes: &[u8]) -> Self {
         match InlineVec::from_slice(bytes) {
             Ok(inline) => Self::from_inline(inline),
-            _ => Self::from_eco(EcoVec::from(bytes)),
+            _ => Self::from(EcoVec::from(bytes)),
         }
     }
 
+    /// Create an empty vector with the given capacity.
     #[inline]
     pub fn with_capacity(capacity: usize) -> Self {
         if capacity <= LIMIT {
             Self::new()
         } else {
-            Self::from_eco(EcoVec::with_capacity(capacity))
+            Self::from(EcoVec::with_capacity(capacity))
         }
     }
 
+    /// Returns `true` if the vector contains no elements.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// The length of the vector.
     #[inline]
     pub fn len(&self) -> usize {
         match self.variant() {
@@ -111,6 +155,18 @@ impl DynamicVec {
         }
     }
 
+    /// How many bytes this vector's backing allocation can hold.
+    ///
+    /// Even if `len < capacity`, pushing into the vector may still allocate if the reference count is larger than one.
+    #[inline]
+    pub fn capacity(&self) -> usize {
+        match self.variant() {
+            Variant::Inline(_) => Self::INLINE_LIMIT,
+            Variant::Spilled(spilled) => spilled.capacity(),
+        }
+    }
+
+    /// A slice containing the entire vector.
     #[inline]
     pub fn as_slice(&self) -> &[u8] {
         match self.variant() {
@@ -119,6 +175,19 @@ impl DynamicVec {
         }
     }
 
+    /// Produce a mutable slice containing the entire vector.
+    ///
+    /// Clones the vector if its reference count is larger than 1.
+    pub fn make_mut(&mut self) -> &mut [u8] {
+        match self.variant_mut() {
+            VariantMut::Inline(inline) => inline.as_slice_mut(),
+            VariantMut::Spilled(_) => todo!(),
+        }
+    }
+
+    /// Add a byte at the end of the vector.
+    ///
+    /// Clones the vector if its reference count is larger than 1.
     #[inline]
     pub fn push(&mut self, byte: u8) {
         match self.variant_mut() {
@@ -127,7 +196,7 @@ impl DynamicVec {
                     let mut eco = EcoVec::with_capacity(inline.len() + 1);
                     eco.extend_from_byte_slice(self.as_slice());
                     eco.push(byte);
-                    *self = Self::from_eco(eco);
+                    *self = Self::from(eco);
                 }
             }
             VariantMut::Spilled(spilled) => {
@@ -136,23 +205,19 @@ impl DynamicVec {
         }
     }
 
+    /// Removes the last byte from a vector and returns it, or `None` if the
+    /// vector is empty.
+    ///
+    /// Clones the vector if its reference count is larger than 1.
     #[inline]
-    pub fn extend_from_slice(&mut self, bytes: &[u8]) {
+    pub fn pop(&mut self) -> Option<u8> {
         match self.variant_mut() {
-            VariantMut::Inline(inline) => {
-                if inline.extend_from_slice(bytes).is_err() {
-                    let mut eco = EcoVec::with_capacity(inline.len() + bytes.len());
-                    eco.extend_from_byte_slice(self.as_slice());
-                    eco.extend_from_byte_slice(bytes);
-                    *self = Self::from_eco(eco);
-                }
-            }
-            VariantMut::Spilled(spilled) => {
-                spilled.extend_from_byte_slice(bytes);
-            }
+            VariantMut::Inline(inline) => inline.pop(),
+            VariantMut::Spilled(spilled) => spilled.pop(),
         }
     }
 
+    /// Clear the vector.
     #[inline]
     pub fn clear(&mut self) {
         match self.variant_mut() {
@@ -161,6 +226,11 @@ impl DynamicVec {
         }
     }
 
+    /// Shortens the vector, keeping the first len elements and dropping the
+    /// rest.
+    ///
+    /// Clones the vector if its reference count is larger than 1 and
+    /// `target < len`.
     #[inline]
     pub fn truncate(&mut self, target: usize) {
         match self.variant_mut() {
@@ -168,13 +238,48 @@ impl DynamicVec {
             VariantMut::Spilled(spilled) => spilled.truncate(target),
         }
     }
-}
 
-impl DynamicVec {
+    /// Reserve space for at least `additional` more elements
+    ///
+    /// Guarantees that the resulting vector has reference count `1` and space for `additional` more elements
+    #[inline]
+    pub fn reserve(&mut self, additional: usize) {
+        match self.variant_mut() {
+            VariantMut::Inline(inline) => {
+                if inline.len() + additional > LIMIT {
+                    //TODO: optimize
+                    let inline = *inline;
+                    *self = Self::with_capacity(inline.len() + additional);
+                    self.extend_from_slice(inline.as_slice())
+                }
+            }
+            VariantMut::Spilled(spilled) => spilled.reserve(additional),
+        }
+    }
+
+    /// Clones and pushes all elements in a slice to the vector.
+    #[inline]
+    pub fn extend_from_slice(&mut self, bytes: &[u8]) {
+        match self.variant_mut() {
+            VariantMut::Inline(inline) => {
+                if inline.extend_from_slice(bytes).is_err() {
+                    let mut eco = EcoVec::with_capacity(inline.len() + bytes.len());
+                    eco.extend_from_byte_slice(self.as_slice());
+                    eco.extend_from_byte_slice(bytes);
+                    *self = Self::from(eco);
+                }
+            }
+            VariantMut::Spilled(spilled) => {
+                spilled.extend_from_byte_slice(bytes);
+            }
+        }
+    }
+
+    /// Check whether this byte vector is stored inline
     // If this returns true, guarantees that `self.0.inline` is initialized.
     // Otherwise, guarantees that `self.0.spilled` is initialized.
     #[inline]
-    fn is_inline(&self) -> bool {
+    pub fn is_inline(&self) -> bool {
         // Safety:
         // We always initialize tagged_len, even for the `EcoVec` variant. For
         // the inline variant the highest-order bit is always `1`. For the
@@ -185,7 +290,18 @@ impl DynamicVec {
         // its initial value.)
         unsafe { self.0.inline.tagged_len & LEN_TAG != 0 }
     }
+}
 
+impl Deref for EcoBytes {
+    type Target = [u8];
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        self.as_slice()
+    }
+}
+
+impl EcoBytes {
     #[inline]
     fn variant(&self) -> Variant<'_> {
         unsafe {
@@ -213,17 +329,17 @@ impl DynamicVec {
     }
 }
 
-impl Clone for DynamicVec {
+impl Clone for EcoBytes {
     #[inline]
     fn clone(&self) -> Self {
         match self.variant() {
             Variant::Inline(inline) => Self::from_inline(*inline),
-            Variant::Spilled(spilled) => Self::from_eco(spilled.clone()),
+            Variant::Spilled(spilled) => Self::from(spilled.clone()),
         }
     }
 }
 
-impl Drop for DynamicVec {
+impl Drop for EcoBytes {
     #[inline]
     fn drop(&mut self) {
         if let VariantMut::Spilled(spilled) = self.variant_mut() {
@@ -232,6 +348,43 @@ impl Drop for DynamicVec {
                 ptr::drop_in_place(spilled);
             }
         }
+    }
+}
+
+impl From<EcoVec<u8>> for EcoBytes {
+    #[inline]
+    fn from(value: EcoVec<u8>) -> Self {
+        // Safety:
+        // Explicitly set `tagged_len` to 0 to mark this as a spilled variant.
+        // Just initializing with `Repr { spilled: ... }` would leave
+        // `tagged_len` unitialized, leading to undefined behaviour on access.
+        let mut repr = Repr {
+            inline: InlineVec { buf: [0; LIMIT], tagged_len: 0 },
+        };
+        repr.spilled = ManuallyDrop::new(value);
+        Self(repr)
+    }
+}
+
+impl From<EcoBytes> for EcoVec<u8> {
+    #[inline]
+    fn from(mut value: EcoBytes) -> Self {
+        match value.variant_mut() {
+            VariantMut::Inline(inline) => EcoVec::from(inline.as_slice()),
+            VariantMut::Spilled(spilled) => {
+                let mut ret = EcoVec::default();
+                core::mem::swap(spilled, &mut ret);
+                core::mem::forget(value);
+                ret
+            }
+        }
+    }
+}
+
+impl From<&'_ [u8]> for EcoBytes {
+    #[inline]
+    fn from(value: &'_ [u8]) -> Self {
+        Self::from_slice(value)
     }
 }
 
@@ -291,6 +444,13 @@ impl InlineVec {
     }
 
     #[inline]
+    pub fn as_slice_mut(&mut self) -> &mut [u8] {
+        let len = self.len();
+        // Safety: We have the invariant `len <= LIMIT`.
+        unsafe { self.buf.get_unchecked_mut(..len) }
+    }
+
+    #[inline]
     pub fn clear(&mut self) {
         unsafe {
             // Safety: Trivially, `0 <= LIMIT`.
@@ -314,6 +474,17 @@ impl InlineVec {
     }
 
     #[inline]
+    pub fn pop(&mut self) -> Option<u8> {
+        let last = self.as_slice().last().copied();
+        let len = self.len().saturating_sub(1);
+        unsafe {
+            // Safety: self.len().saturating_sub(1) <= self.len()
+            self.set_len(len);
+        }
+        last
+    }
+
+    #[inline]
     pub fn extend_from_slice(&mut self, bytes: &[u8]) -> Result<(), ()> {
         let len = self.len();
         let grown = len + bytes.len();
@@ -333,10 +504,15 @@ impl InlineVec {
     pub fn truncate(&mut self, target: usize) {
         if target < self.len() {
             unsafe {
-                // Safety: Jecked that it's smaller than the current length,
+                // Safety: Checked that it's smaller than the current length,
                 // which cannot exceed LIMIT itself.
                 self.set_len(target);
             }
         }
     }
+}
+
+#[cold]
+const fn exceeded_inline_capacity() -> ! {
+    panic!("exceeded inline capacity");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,9 +51,9 @@ pub mod bytes;
 pub mod string;
 pub mod vec;
 
+pub use self::bytes::EcoBytes;
 pub use self::string::EcoString;
 pub use self::vec::EcoVec;
-pub use self::bytes::EcoBytes;
 
 // Run doctests on the README too
 #[doc = include_str!("../README.md")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,12 +47,13 @@ assert_eq!(third, "Welcome to earth! ");
 
 extern crate alloc;
 
-mod dynamic;
+pub mod bytes;
 pub mod string;
 pub mod vec;
 
 pub use self::string::EcoString;
 pub use self::vec::EcoVec;
+pub use self::bytes::EcoBytes;
 
 // Run doctests on the README too
 #[doc = include_str!("../README.md")]

--- a/src/string.rs
+++ b/src/string.rs
@@ -10,6 +10,7 @@ use core::hash::{Hash, Hasher};
 use core::ops::{Add, AddAssign, Deref};
 
 use crate::bytes::{EcoBytes, InlineVec};
+use crate::EcoVec;
 
 /// Create a new [`EcoString`] from a format string.
 /// ```
@@ -449,6 +450,40 @@ impl From<&EcoString> for String {
     #[inline]
     fn from(s: &EcoString) -> Self {
         s.as_str().into()
+    }
+}
+
+impl From<EcoString> for EcoBytes {
+    #[inline]
+    fn from(value: EcoString) -> Self {
+        value.0
+    }
+}
+
+impl TryFrom<EcoBytes> for EcoString {
+    type Error = core::str::Utf8Error;
+
+    #[inline]
+    fn try_from(value: EcoBytes) -> Result<Self, Self::Error> {
+        core::str::from_utf8(value.as_slice())?;
+        Ok(Self(value))
+    }
+}
+
+impl From<EcoString> for EcoVec<u8> {
+    #[inline]
+    fn from(value: EcoString) -> Self {
+        value.0.into()
+    }
+}
+
+impl TryFrom<EcoVec<u8>> for EcoString {
+    type Error = core::str::Utf8Error;
+
+    #[inline]
+    fn try_from(value: EcoVec<u8>) -> Result<Self, Self::Error> {
+        core::str::from_utf8(value.as_slice())?;
+        Ok(Self(value.into()))
     }
 }
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -523,8 +523,6 @@ fn test_bytes_insert() {
     }
 }
 
-
-
 #[test]
 #[should_panic(expected = "index is out bounds (index: 4, len: 3)")]
 fn test_bytes_insert_fail() {


### PR DESCRIPTION
Add `EcoBytes`, which is the same as `EcoString` but holds a raw byte vector rather than a UTF-8 string; this is implemented by making `DynamicVec` public.