### PR TITLE
Make `EcoVec` generic over choice of reference count type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,13 +43,14 @@ assert_eq!(third, "Welcome to earth! ");
 
 extern crate alloc;
 
+pub mod refcount;
 pub mod string;
 pub mod vec;
 
 mod dynamic;
 
 pub use self::string::EcoString;
-pub use self::vec::EcoVec;
+pub use self::vec::{sync::ArcVec, unsync::RcVec, EcoVec};
 
 #[cfg(doc)]
 use alloc::{string::String, sync::Arc, vec::Vec};

--- a/src/refcount.rs
+++ b/src/refcount.rs
@@ -1,9 +1,15 @@
 //! Traits for types that can be used as reference counts.
 
-use core::sync::atomic::{self, AtomicUsize, Ordering};
+use core::sync::atomic::{
+    self, AtomicU16, AtomicU32, AtomicU64, AtomicU8, AtomicUsize, Ordering,
+};
 
 /// A type that can be used as a (potentially non-atomic) reference count.
 pub trait RefCount {
+    /// The maximum signed representation of ths type. Used to check for
+    /// overflow after incrementing the reference count.
+    const SIGNED_MAX: isize;
+
     /// Create a new reference count, initialised to `count`.
     fn new(count: usize) -> Self;
 
@@ -25,56 +31,80 @@ pub trait RefCount {
 /// Types that implement this trait must ensure that their methods do not ignore the `order` argument
 pub unsafe trait AtomicRefCount: RefCount {}
 
-impl RefCount for AtomicUsize {
-    #[inline(always)]
-    fn new(count: usize) -> Self {
-        Self::new(count)
-    }
+macro_rules! impl_atomic_refcount {
+    ($atomic_ty:ty, $non_atomic_ty:ty, $non_atomic_signed_ty:ty) => {
+        impl RefCount for $atomic_ty {
+            const SIGNED_MAX: isize = <$non_atomic_signed_ty>::MAX as isize;
 
-    #[inline(always)]
-    fn load(&self, order: Ordering) -> usize {
-        self.load(order)
-    }
+            #[inline(always)]
+            fn new(count: usize) -> Self {
+                Self::new(count as $non_atomic_ty)
+            }
 
-    #[inline(always)]
-    fn fetch_add(&self, val: usize, order: Ordering) -> usize {
-        self.fetch_add(val, order)
-    }
+            #[inline(always)]
+            fn load(&self, order: Ordering) -> usize {
+                self.load(order) as usize
+            }
 
-    #[inline(always)]
-    fn fetch_sub(&self, val: usize, order: Ordering) -> usize {
-        self.fetch_sub(val, order)
-    }
+            #[inline(always)]
+            fn fetch_add(&self, val: usize, order: Ordering) -> usize {
+                self.fetch_add(val as $non_atomic_ty, order) as usize
+            }
 
-    #[inline(always)]
-    fn fence(order: Ordering) {
-        atomic::fence(order)
-    }
+            #[inline(always)]
+            fn fetch_sub(&self, val: usize, order: Ordering) -> usize {
+                self.fetch_sub(val as $non_atomic_ty, order) as usize
+            }
+
+            #[inline(always)]
+            fn fence(order: Ordering) {
+                atomic::fence(order)
+            }
+        }
+
+        unsafe impl AtomicRefCount for $atomic_ty {}
+    };
 }
 
-unsafe impl AtomicRefCount for AtomicUsize {}
+impl_atomic_refcount!(AtomicUsize, usize, isize);
+impl_atomic_refcount!(AtomicU64, u64, i64);
+impl_atomic_refcount!(AtomicU32, u32, i32);
+impl_atomic_refcount!(AtomicU16, u16, i16);
+impl_atomic_refcount!(AtomicU8, u8, i8);
 
-impl RefCount for usize {
-    #[inline(always)]
-    fn new(count: usize) -> Self {
-        count
-    }
+macro_rules! impl_refcount {
+    ($ty:ty, $signed_ty:ty) => {
+        impl RefCount for $ty {
+            const SIGNED_MAX: isize = <$signed_ty>::MAX as isize;
 
-    #[inline(always)]
-    fn load(&self, _: Ordering) -> usize {
-        *self
-    }
+            #[inline(always)]
+            fn new(count: usize) -> Self {
+                count as Self
+            }
 
-    #[inline(always)]
-    fn fetch_add(&self, amount: usize, _: Ordering) -> usize {
-        *self + amount
-    }
+            #[inline(always)]
+            fn load(&self, _: Ordering) -> usize {
+                (*self) as usize
+            }
 
-    #[inline(always)]
-    fn fetch_sub(&self, amount: usize, _: Ordering) -> usize {
-        *self - amount
-    }
+            #[inline(always)]
+            fn fetch_add(&self, amount: usize, _: Ordering) -> usize {
+                (*self + amount as Self) as usize
+            }
 
-    #[inline(always)]
-    fn fence(_: Ordering) {}
+            #[inline(always)]
+            fn fetch_sub(&self, amount: usize, _: Ordering) -> usize {
+                (*self - amount as Self) as usize
+            }
+
+            #[inline(always)]
+            fn fence(_: Ordering) {}
+        }
+    };
 }
+
+impl_refcount!(usize, isize);
+impl_refcount!(u64, i64);
+impl_refcount!(u32, i32);
+impl_refcount!(u16, i64);
+impl_refcount!(u8, i8);

--- a/src/refcount.rs
+++ b/src/refcount.rs
@@ -1,0 +1,80 @@
+//! Traits for types that can be used as reference counts.
+
+use core::sync::atomic::{self, AtomicUsize, Ordering};
+
+/// A type that can be used as a (potentially non-atomic) reference count.
+pub trait RefCount {
+    /// Create a new reference count, initialised to `count`.
+    fn new(count: usize) -> Self;
+
+    /// Load the reference count.
+    fn load(&self, order: Ordering) -> usize;
+
+    /// Increment the reference count.
+    fn fetch_add(&self, amount: usize, order: Ordering) -> usize;
+
+    /// Decrement the reference count.
+    fn fetch_sub(&self, amount: usize, order: Ordering) -> usize;
+
+    /// Insert a fence.
+    fn fence(order: Ordering);
+}
+
+/// A type that can be used as an atomic reference count.
+/// # Safety
+/// Types that implement this trait must ensure that their methods do not ignore the `order` argument
+pub unsafe trait AtomicRefCount: RefCount {}
+
+impl RefCount for AtomicUsize {
+    #[inline(always)]
+    fn new(count: usize) -> Self {
+        Self::new(count)
+    }
+
+    #[inline(always)]
+    fn load(&self, order: Ordering) -> usize {
+        self.load(order)
+    }
+
+    #[inline(always)]
+    fn fetch_add(&self, val: usize, order: Ordering) -> usize {
+        self.fetch_add(val, order)
+    }
+
+    #[inline(always)]
+    fn fetch_sub(&self, val: usize, order: Ordering) -> usize {
+        self.fetch_sub(val, order)
+    }
+
+    #[inline(always)]
+    fn fence(order: Ordering) {
+        atomic::fence(order)
+    }
+}
+
+unsafe impl AtomicRefCount for AtomicUsize {}
+
+impl RefCount for usize {
+    #[inline(always)]
+    fn new(count: usize) -> Self {
+        count
+    }
+
+    #[inline(always)]
+    fn load(&self, _: Ordering) -> usize {
+        *self
+    }
+
+    #[inline(always)]
+    fn fetch_add(&self, amount: usize, _: Ordering) -> usize {
+        *self + amount
+    }
+
+    #[inline(always)]
+    fn fetch_sub(&self, amount: usize, _: Ordering) -> usize {
+        *self - amount
+    }
+
+    #[inline(always)]
+    fn fence(_: Ordering) {}
+}

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -825,7 +825,7 @@ impl<T: Clone, RC: RefCount> Clone for EcoVec<T, RC> {
             let prev = header.refs.fetch_add(1, Relaxed);
 
             // See Arc's clone impl details about guarding against incredibly degenerate programs
-            if prev > isize::MAX as usize {
+            if prev > RC::SIGNED_MAX as usize {
                 ref_count_overflow::<T, RC>(self.ptr, self.len);
             }
         }

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -16,9 +16,10 @@ use crate::sync::atomic::Ordering::*;
 
 /// An `EcoVec` that cannot be shared between multiple threads.
 pub mod unsync {
+    use core::cell::Cell;
 
     /// An `EcoVec` that cannot be shared between multiple threads.
-    pub type RcVec<T> = super::EcoVec<T, usize>;
+    pub type RcVec<T> = super::EcoVec<T, Cell<usize>>;
 
     #[macro_export]
     /// Create a new [`RcVec`] with the given elements.
@@ -60,6 +61,7 @@ pub mod sync {
 /// # use ecow::eco_vec;
 /// # use ecow::EcoVec;
 /// # use core::sync::atomic::AtomicUsize;
+/// # use core::cell::Cell;
 /// let vec: EcoVec<i32, AtomicUsize> = eco_vec![];
 /// assert_eq!(vec, []);
 ///
@@ -69,10 +71,10 @@ pub mod sync {
 /// let vec: EcoVec<i32, AtomicUsize> = eco_vec![1, 2, 3];
 /// assert_eq!(vec, [1, 2, 3]);
 ///
-/// let vec: EcoVec<i32, usize> = eco_vec![1; 4];
+/// let vec: EcoVec<i32, Cell<usize>> = eco_vec![1; 4];
 /// assert_eq!(vec, [1; 4]);
 ///
-/// let vec: EcoVec<i32, usize> = eco_vec![1, 2, 3];
+/// let vec: EcoVec<i32, Cell<usize>> = eco_vec![1, 2, 3];
 /// assert_eq!(vec, [1, 2, 3]);
 /// ```
 #[macro_export]

--- a/tests/loom.rs
+++ b/tests/loom.rs
@@ -10,12 +10,12 @@ mod loom {
         "Loom tests are typically slow in debug mode. Run them with `--release`"
     );
 
-    use ecow::eco_vec;
+    use ecow::arc_vec;
 
     #[test]
     fn smoke() {
         loom::model(|| {
-            let mut one = eco_vec![1, 2, 3];
+            let mut one = arc_vec![1, 2, 3];
             let two = one.clone();
 
             loom::thread::spawn(move || {

--- a/tests/ub_guards.rs
+++ b/tests/ub_guards.rs
@@ -1,4 +1,4 @@
-use ecow::{eco_vec, EcoVec};
+use ecow::{arc_vec, ArcVec};
 
 // Guarding against something like:
 // https://github.com/servo/rust-smallvec/issues/96 aka RUSTSEC-2018-0003
@@ -21,7 +21,7 @@ fn panicky_iterator_unwinds_correctly() {
         }
     }
 
-    let mut v = eco_vec![1, 2, 3];
+    let mut v = arc_vec![1, 2, 3];
     v.extend(PanicIter);
 }
 
@@ -30,7 +30,7 @@ fn panicky_iterator_unwinds_correctly() {
 // size_hint should only be treated as a hint, nothing more.
 #[test]
 fn small_size_hint_is_fine() {
-    let mut v = EcoVec::new();
+    let mut v = ArcVec::new();
     v.push(123);
 
     let iter = (0u8..=255).filter(|n| n % 2 == 0);
@@ -71,7 +71,7 @@ fn wacky_size_hint_is_fine() {
         }
     }
 
-    let mut v = EcoVec::new();
+    let mut v = ArcVec::new();
     v.extend(IncorrectIterator::new());
 
     assert_eq!(v, IncorrectIterator::new().collect::<Vec<_>>())


### PR DESCRIPTION
This patch adds a reference count type parameter to `EcoVec<T>`, allowing it to be used with non-atomic reference counts if the vec is only being used on a single thread.

I left `EcoString` non-generic over refence counts, but that could also be made generic in a future patch.