### PR TITLE
Add `#[inline]` annotation to the `max()` function.

### DIFF
--- a/src/vec.rs
+++ b/src/vec.rs
@@ -1176,6 +1176,7 @@ fn out_of_bounds(index: usize, len: usize) -> ! {
 }
 
 // Copy of `std::cmp::max::<usize>()` that is callable in `const` contexts
+#[inline]
 const fn max(x: usize, y: usize) -> usize {
     if x > y {
         x


### PR DESCRIPTION
This function is called from `EcoVec::align()` and `EcoVec::offset()` functions. Although they are marked `#[inline]`, and `max` is private, [that is not sufficient to ensure it is inlined](https://github.com/matklad/benchmarks/tree/91171269f0a6e260a27111d07661021a89d20085/rust-inline), and as a result, `EcoVec::new()` and related functions have 2 calls to `max` in them!

# Before
```asm
cargo asm --release
    Finished release [optimized] target(s) in 0.00s

.section .text.uses_ecow::new,"ax",@progbits
        .globl  uses_ecow::new
        .p2align        4, 0x90
        .type   uses_ecow::new,@function
uses_ecow::new:

        .cfi_startproc
        push rbx
        .cfi_def_cfa_offset 16
        .cfi_offset rbx, -16
        mov rbx, qword ptr [rip + ecow::vec::max@GOTPCREL]
        mov edi, 8
        mov esi, 4
        call rbx

        mov edi, 16
        mov rsi, rax
        call rbx

        xor edx, edx
        pop rbx
        .cfi_def_cfa_offset 8
        ret

```

# After
```asm
cargo asm --release                                   
    Finished release [optimized] target(s) in 0.00s

.section .text.uses_ecow::new,"ax",@progbits
        .globl  uses_ecow::new
        .p2align        4, 0x90
        .type   uses_ecow::new,@function
uses_ecow::new:

        .cfi_startproc
        mov eax, 16
        xor edx, edx
        ret
```