### PR TITLE
Add `From<&String> for EcoString` impl

### DIFF
--- a/src/string.rs
+++ b/src/string.rs
@@ -438,6 +438,13 @@ impl From<String> for EcoString {
     }
 }
 
+impl From<&String> for EcoString {
+    #[inline]
+    fn from(s: &String) -> Self {
+        Self::from_str(s.as_str())
+    }
+}
+
 impl From<Cow<'_, str>> for EcoString {
     #[inline]
     fn from(s: Cow<str>) -> Self {


### PR DESCRIPTION
Allows converting from `&String` into `EcoString` for convenience. Otherwise, one has to do `string.as_str().into()`.
Since converting `String` to `EcoString` already allocates/copies, then adding this impl for `&String` shouldn't be any different.