### PR TITLE
Add `From<&EcoString> for EcoString` impl

### DIFF
--- a/src/string.rs
+++ b/src/string.rs
@@ -447,6 +447,13 @@ impl From<&String> for EcoString {
     }
 }
 
+impl From<&EcoString> for EcoString {
+    #[inline]
+    fn from(s: &EcoString) -> Self {
+        s.clone()
+    }
+}
+
 impl From<Cow<'_, str>> for EcoString {
     #[inline]
     fn from(s: Cow<str>) -> Self {


### PR DESCRIPTION
Add an impl like `impl From<&String> for String` to allow convert `&EcoString` to `EcoString`. In my use case, this will enable function to take param as `impl Into<EcoString>`, so it can receive either `&EcoString` or `EcoString`.