### PR TITLE
Optimize From<Vec<T>> for EcoVec<T>

### DIFF
--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -50,6 +50,23 @@ fn test_vec_construction() {
 }
 
 #[test]
+fn test_from_vec_rc() {
+    use std::rc::Rc;
+
+    let x = Rc::new(());
+    let v = vec![x.clone()];
+    assert_eq!(Rc::strong_count(&x), 2);
+
+    let vec = EcoVec::from(v);
+    assert_eq!(Rc::strong_count(&x), 2, "Rc count should not change");
+    assert_eq!(vec.len(), 1);
+    assert!(Rc::ptr_eq(&x, &vec[0]));
+
+    std::mem::drop(vec);
+    assert_eq!(Rc::strong_count(&x), 1);
+}
+
+#[test]
 fn test_vec_with_capacity() {
     let mut vec = EcoVec::with_capacity(3);
     assert_eq!(vec.capacity(), 3);


### PR DESCRIPTION
Inspired by the implementation of `From<Vec<T>>` for `Arc<[T]>`:
https://github.com/rust-lang/rust/blob/175e04331be56c5b4bdf77478434b1a5e0556770/library/alloc/src/sync.rs#L3823-L3851

- [`Vec::into_raw_parts(self)`](https://github.com/rust-lang/rust/issues/65816) APIs are experimental, so we can't use them, even though the stdlib Arc implementation uses it internally.

---

When we copy/move the elements from the Vec into the EcoVec, we need to ensure that the items don't get dropped twice.
- For this we use `Vec::set_len(&mut self, len: usize)` to set the length to 0, which ensures that when the Vec is dropped later, and its buffer is freed - it doesn't run drop on the individual items that were moved into the EcoVec.