### PR TITLE
Implement `FromIterator<&str>` for `EcoString`

### DIFF
--- a/src/string.rs
+++ b/src/string.rs
@@ -514,6 +514,17 @@ impl FromIterator<char> for EcoString {
     }
 }
 
+impl<'a> FromIterator<&'a str> for EcoString {
+    #[inline]
+    fn from_iter<T: IntoIterator<Item = &'a str>>(iter: T) -> Self {
+        let mut s = Self::new();
+        for sub in iter {
+            s.push_str(sub);
+        }
+        s
+    }
+}
+
 impl FromIterator<Self> for EcoString {
     #[inline]
     fn from_iter<T: IntoIterator<Item = Self>>(iter: T) -> Self {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -473,6 +473,10 @@ fn test_str_construction() {
 
     assert_eq!(str_from_eco_string, str_from_eco_string_ref);
     assert_eq!(str_from_eco_string_ref, "foo");
+
+    let from_string_iter: EcoString = ["foo", " ", "bar"].into_iter().collect();
+
+    assert_eq!(from_string_iter, "foo bar");
 }
 
 #[test]


### PR DESCRIPTION
Pretty straightforward idea and implementation. Something I found appropriate and that I found lacking throughout my personal usage of the crate.