### PR TITLE
Fix retain comment to make more sense

### DIFF
--- a/src/vec.rs
+++ b/src/vec.rs
@@ -378,7 +378,7 @@ impl<T: Clone> EcoVec<T> {
     ///
     /// Clones the vector if its reference count is larger than 1.
     ///
-    /// Note that this clones the vector even if `f` always returns `false`. To
+    /// Note that this clones the vector even if `f` always returns `true`. To
     /// prevent that, you can first iterate over the vector yourself and then
     /// only call `retain` if your condition is `false` for some element.
     pub fn retain<F>(&mut self, mut f: F)


### PR DESCRIPTION
This changes the retain doc comment from:
Note that this clones the vector even if `f` always returns `false`. To prevent that, you can first iterate over the vector yourself and then only call `retain` if your condition is `false` for some element.

To:
Note that this clones the vector even if `f` always returns `true`. To prevent that, you can first iterate over the vector yourself and then only call `retain` if your condition is `false` for some element.

This makes more sense, since if `f` always returns true, nothing is changed, so common sense would be that the vector wouldn't be cloned, but this comment says otherwise.