### PR TITLE
Add `ToEcoString` trait

### DIFF
--- a/src/string.rs
+++ b/src/string.rs
@@ -593,6 +593,21 @@ impl FromStr for EcoString {
     }
 }
 
+/// A trait for converting a value to an [`EcoString`].
+///
+/// This trait is automatically implemented for any type which implements the
+/// [`Display`] trait.
+pub trait ToEcoString {
+    /// Converts the given value to an [`EcoString`].
+    fn to_eco_string(&self) -> EcoString;
+}
+
+impl<T: Display + ?Sized> ToEcoString for T {
+    fn to_eco_string(&self) -> EcoString {
+        eco_format!("{self}")
+    }
+}
+
 #[cold]
 const fn exceeded_inline_capacity() -> ! {
     panic!("exceeded inline capacity");

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -9,6 +9,7 @@ use std::fmt::Write;
 use std::mem;
 use std::sync::atomic::{AtomicUsize, Ordering::*};
 
+use ecow::string::ToEcoString;
 use ecow::{eco_vec, EcoString, EcoVec};
 
 const ALPH: &str = "abcdefghijklmnopqrstuvwxyz";
@@ -624,4 +625,10 @@ fn test_str_complex() {
 
     assert_eq!(hash_map.get("foo").unwrap(), &["bar".into(), "foo".into(), "foo".into()]);
     assert_eq!(hash_map.get("bar").unwrap(), &["bar".into()]);
+}
+
+#[test]
+fn test_str_to_eco_string() {
+    let num = 123456789;
+    assert_eq!(num.to_eco_string(), "123456789");
 }


### PR DESCRIPTION
This adds an `ToEcoString` trait, adding the `to_eco_string()` method for cases that would previously require `eco_format!("{}", <expr>)`

It's based on the `splice` branch, so should be merged after #59 