### PR TITLE
Optimize reserve for non-unique EcoVec

### DIFF
--- a/src/vec.rs
+++ b/src/vec.rs
@@ -464,7 +464,7 @@ impl<T: Clone> EcoVec<T> {
             let mut vec = Self::with_capacity(target);
             unsafe {
                 // Safety:
-                // Slice iterator implements ExactSizeIterator.
+                // - Slice iterator implements `TrustedLen`.
                 vec.extend_from_trusted(self.iter().cloned());
             }
             *self = vec;

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -462,7 +462,11 @@ impl<T: Clone> EcoVec<T> {
 
         if !self.is_unique() {
             let mut vec = Self::with_capacity(target);
-            vec.extend(self.iter().cloned());
+            unsafe {
+                // Safety:
+                // Slice iterator implements ExactSizeIterator.
+                vec.extend_from_trusted(self.iter().cloned());
+            }
             *self = vec;
         } else if target > capacity {
             unsafe {


### PR DESCRIPTION
This PR avoids bounds checking when calling reserve on a non-unique EcoVec when it has to clone over all the values to a new EcoVec.

Some results, before/after:

```
size=   100, reserve=   500:       1593 ns/iter
size=  1000, reserve=  5000:       9057 ns/iter
size= 10000, reserve= 50000:      89608 ns/iter
size=100000, reserve=500000:     895274 ns/iter
```

```
size=   100, reserve=   500:        637 ns/iter
size=  1000, reserve=  5000:       5752 ns/iter
size= 10000, reserve= 50000:      51176 ns/iter
size=100000, reserve=500000:     513765 ns/iter
```
