### PR TITLE
Add `#[clippy::format_args]` to `eco_format` macro

### DIFF
--- a/src/string.rs
+++ b/src/string.rs
@@ -23,6 +23,7 @@ use crate::dynamic::{DynamicVec, InlineVec};
 /// assert_eq!(eco_format!("Hello, {}!", 123), "Hello, 123!");
 /// ```
 #[macro_export]
+#[clippy::format_args]
 macro_rules! eco_format {
     ($($tts:tt)*) => {{
         use ::std::fmt::Write;


### PR DESCRIPTION
This allows us to get clippy lints on `eco_format!` calls. See: <https://doc.rust-lang.org/clippy/attribs.html#clippyformat_args>

This is related to https://github.com/typst/typst/pull/8335
